### PR TITLE
Xpt2046 correct alignment

### DIFF
--- a/xpt2046.py
+++ b/xpt2046.py
@@ -132,4 +132,4 @@ class Touch(object):
         self.spi.write_readinto(self.tx_buf, self.rx_buf)
         self.cs(1)
 
-        return (self.rx_buf[1] << 4) | (self.rx_buf[2] >> 4)
+        return (self.rx_buf[1] << 5) | (self.rx_buf[2] >> 3)


### PR DESCRIPTION
The bitshifts for the xpt2046 are off. The values from the touch were very noisy because they have been accidentally including the busy bit in their value. You should find you need much less averaging to get a useful result.

Regards,
John